### PR TITLE
[Development] Add jobs configuration via YAML files

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,6 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
+pyyaml = "*"
 
 [dev-packages]
 pyspark = "3.1.1"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "395682438405b92c19c8e041a9f669ac0d1d09c38f2744ab67899753c74bf8ac"
+            "sha256": "8f1d27973254c46d54f136ecd8baab9b6cd703284d3630ed06c2afaa19944ce5"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -15,7 +15,43 @@
             }
         ]
     },
-    "default": {},
+    "default": {
+        "pyyaml": {
+            "hashes": [
+                "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf",
+                "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696",
+                "sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393",
+                "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77",
+                "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922",
+                "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5",
+                "sha256:4465124ef1b18d9ace298060f4eccc64b0850899ac4ac53294547536533800c8",
+                "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10",
+                "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc",
+                "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018",
+                "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e",
+                "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253",
+                "sha256:72a01f726a9c7851ca9bfad6fd09ca4e090a023c00945ea05ba1638c09dc3347",
+                "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183",
+                "sha256:895f61ef02e8fed38159bb70f7e100e00f471eae2bc838cd0f4ebb21e28f8541",
+                "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb",
+                "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185",
+                "sha256:bfb51918d4ff3d77c1c856a9699f8492c612cde32fd3bcd344af9be34999bfdc",
+                "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db",
+                "sha256:cb333c16912324fd5f769fff6bc5de372e9e7a202247b48870bc251ed40239aa",
+                "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46",
+                "sha256:d483ad4e639292c90170eb6f7783ad19490e7a8defb3e46f97dfe4bacae89122",
+                "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b",
+                "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63",
+                "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df",
+                "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc",
+                "sha256:fd7f6999a8070df521b6384004ef42833b9bd62cfee11a09bda1079b4b704247",
+                "sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6",
+                "sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0"
+            ],
+            "index": "pypi",
+            "version": "==5.4.1"
+        }
+    },
     "develop": {
         "astroid": {
             "hashes": [
@@ -94,7 +130,7 @@
                 "sha256:f0b278ce10936db1a37e6954e15a3730bea96a0997c26d7fee88e6c396c2086d",
                 "sha256:f11642dddbb0253cc8853254301b51390ba0081750a8ac03f20ea8103f0c56b6"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==5.5"
         },
         "isort": {
@@ -102,7 +138,7 @@
                 "sha256:c729845434366216d320e936b8ad6f9d681aab72dc7cbc2d51bedc3582f3ad1e",
                 "sha256:fff4f0c04e1825522ce6949973e83110a6e907750cd92d128b0d14aaaadbffdc"
             ],
-            "markers": "python_version >= '3.6' and python_version < '4.0'",
+            "markers": "python_version >= '3.6' and python_version < '4'",
             "version": "==5.7.0"
         },
         "lazy-object-proxy": {

--- a/config/tests_config.yaml
+++ b/config/tests_config.yaml
@@ -1,0 +1,3 @@
+### This file is only for running tests. ###
+
+input_data: ../tests/_data

--- a/src/shared/spark.py
+++ b/src/shared/spark.py
@@ -1,15 +1,22 @@
 """
 This module contains helper function to initialize SparkSession object.
 """
-import os
+from typing import List
 
+import os
+import yaml
+
+from pyspark import SparkFiles
 from pyspark.sql import SparkSession
 
 import __main__
 from src.shared.logging import Log4jWrapper
 
 
-def start_spark_session(app_name: str) -> tuple:
+CONFIG_FILE_SUFFIX = "_config.yaml"
+
+
+def start_spark_session(app_name: str, files: List[str] = None) -> tuple:
     """
     Starts Spark session and initialize Spark Log4j logger wrapper.
     Returns session and logger objects as tuple.
@@ -23,9 +30,20 @@ def start_spark_session(app_name: str) -> tuple:
     interactive console session or from an environment which has a `DEBUG`
     environment variable set as '1' (e.g. by default in Visual Studio Code).
 
+    The function looks for a files ending with '_config.yaml' that can be sent
+    with the Spark job. If it is found, it is opened, the contents parsed
+    (assuming it contains valid YAML) into a dict of ETL job configuration
+    parameters, which are returned as the last element in the tuple
+    returned by this function. If the file cannot be found then the return
+    tuple only contains the Spark session and Spark logger objects
+    and None for config.
+
     :param app_name: name of Spark application.
-    :return: a tuple with Spark session and Spark logger wrapper objects.
+    :param files: list of files to send to Spark cluster (master and workers).
+    :return: a tuple with Spark session and Spark logger wrapper objects and
+             config dict if presented.
     """
+    files = files or []
     spark_builder: SparkSession.Builder = SparkSession.builder.appName(app_name)
 
     # Detect execution environment type
@@ -33,8 +51,28 @@ def start_spark_session(app_name: str) -> tuple:
         # Determined as local, add more parameters
         spark_builder.master("local[*]")
 
+        # Add additional files
+        spark_builder.config('spark.files', ','.join(files))
+
     # Create session and logger objects
     spark_session: SparkSession = spark_builder.getOrCreate()
     logger: Log4jWrapper = Log4jWrapper(spark_session.sparkContext)
 
-    return (spark_session, logger)
+    # Get configuration from config files
+    # get config file if sent to cluster with --files
+    spark_files_dir = SparkFiles.getRootDirectory()
+    config_files = [filename for filename in os.listdir(spark_files_dir)
+                    if filename.endswith(CONFIG_FILE_SUFFIX)]
+
+    if config_files:
+        config_dict: dict = {}
+        for cfg_file in config_files:
+            path_to_config_file = os.path.join(spark_files_dir, cfg_file)
+            with open(path_to_config_file, 'r') as config_file:
+                config_dict = {**config_dict, **yaml.safe_load(config_file)}
+            logger.info(f"parsed config file: {cfg_file}")
+    else:
+        logger.info('no config files found')
+        config_dict = None
+
+    return (spark_session, logger, config_dict)

--- a/tests/shared/test_logging.py
+++ b/tests/shared/test_logging.py
@@ -3,10 +3,7 @@ This module contains tests for `shared.logging` module.
 """
 import unittest
 
-from pyspark.sql import SparkSession
-
 from src.shared.spark import start_spark_session
-from src.shared.logging import Log4jWrapper
 
 
 class Log4jWrapperTests(unittest.TestCase):
@@ -14,8 +11,12 @@ class Log4jWrapperTests(unittest.TestCase):
     Test suite for shared.logging.Log4jWrapper class tests.
     """
     def setUp(self):
-        _, logger = start_spark_session("test-app")
+        spark_session, logger, _ = start_spark_session("test-app")
         self.logger = logger
+        self.spark_session = spark_session
+
+    def tearDown(self):
+        self.spark_session.stop()
 
     def test_log_info(self):
         """

--- a/tests/shared/test_spark.py
+++ b/tests/shared/test_spark.py
@@ -11,16 +11,16 @@ from src.shared.logging import Log4jWrapper
 
 class StartSparkSessionTests(unittest.TestCase):
     """
-    Test suite for shared.spark.start_spark_session() function tests.
+    Test suite for shared.spark.start_spark_session() function tests
     """
     def test_start_spark_session(self):
         """
-        Test: Function start_spark_session() creates Spark session.
+        Test: Function start_spark_session() creates Spark session
         """
         res = start_spark_session("test-app")
 
         self.assertIsNotNone(res, "")
-        self.assertEqual(2, len(res), "")
+        self.assertEqual(3, len(res), "")
 
         spark_session: SparkSession = res[0]
         self.assertTrue(isinstance(spark_session, SparkSession), "")
@@ -28,6 +28,22 @@ class StartSparkSessionTests(unittest.TestCase):
 
         logger: Log4jWrapper = res[1]
         self.assertTrue(isinstance(logger, Log4jWrapper), "")
+
+        self.assertIsNone(res[2])
+
+        spark_session.stop()
+
+    def test_start_spark_session_with_config(self):
+        """
+        Test: Function start_spark_session() loads config from file
+        """
+        spark_session, _, config = start_spark_session(
+            "test-app", files=["config/tests_config.yaml"])
+
+        self.assertIsNotNone(config)
+        self.assertTrue("input_data" in config)
+
+        spark_session.stop()
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description

Add an ability to propagate any parameters to the job's Python code by specifying it in a YAML file.

Configuration files contract:
* it should be ended with `_config.yaml`. 
* it should be propagated to Spark cluster via `--files` option

Helper function `start_spark_session` scans the Spark root directory and loads and merges data from all files with the suffix.

The loaded configuration is returned with Spark session and logger object as the third element of the result tuple.

Also, add tests for new functionality.

## Testing

Tested with unit tests:

![image](https://user-images.githubusercontent.com/78155496/111278182-b3634600-8652-11eb-93cb-8bf2ff7ff2ea.png)
